### PR TITLE
Changed 'Pair Liquidity Token' to display token short_name

### DIFF
--- a/src/components/GenerateOffer.tsx
+++ b/src/components/GenerateOffer.tsx
@@ -267,7 +267,9 @@ const GenerateOffer: React.FC<GenerateOfferProps> = ({ data, setOrderRefreshActi
                 {a.map(e => (
                     <li key={e[0].asset_id}>
                         {/* If swap, add dev fee on top of quote */}
-                        {amountWithFee(e)} {process.env.NEXT_PUBLIC_XCH === "TXCH" && e[0].name === "Chia" ? "Testnet Chia" : e[0].name}{" "}
+                        {amountWithFee(e)}{" "}
+                        {process.env.NEXT_PUBLIC_XCH === "TXCH" && e[0].name === "Chia" ? "Testnet Chia"
+                        : e[0].name === "Pair Liquidity Token" ? e[0].short_name : e[0].name}{" "}
                         {e[1] ? <></> : <button
                             className="ml-1 bg-brandDark hover:bg-brandDark/80 text-white px-2 rounded-lg"
                             onClick={() => copyToClipboard(e[0].asset_id)}


### PR DESCRIPTION
"Pair Liquidity Token" now will display: "TIBET-DBX-XCH" for example to clear up confusion from some users who may think the liquidity token is the same for all pairs.