### PR TITLE
Include CopyButton for both token and XCH values of generate offers to enhance user experience

### DIFF
--- a/src/components/shared/CopyButton.tsx
+++ b/src/components/shared/CopyButton.tsx
@@ -1,13 +1,14 @@
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect, ReactNode } from 'react';
 
 interface CopyButtonProps {
-    copyText: string;
-    height?: string;
-    disabled?: boolean;
-    children: string;
+  copyText: string;
+  height?: string;
+  disabled?: boolean;
+  children: ReactNode;
+  variant?: "invisible"
 }
 
-const CopyButton = ({ copyText, height, disabled=false, children }: CopyButtonProps) => {
+const CopyButton = ({ copyText, height, disabled=false, variant, children }: CopyButtonProps) => {
   const [isCopied, setIsCopied] = useState(false);
   const buttonRef = useRef<HTMLButtonElement>(null);
 
@@ -15,7 +16,7 @@ const CopyButton = ({ copyText, height, disabled=false, children }: CopyButtonPr
   useEffect(() => {
     if (buttonRef.current) {
         const buttonWidth = buttonRef.current.offsetWidth;
-        buttonRef.current.style.width = `${buttonWidth}px`;
+        buttonRef.current.style.minWidth = `${buttonWidth}px`;
     }
   },[])
 
@@ -37,9 +38,25 @@ const CopyButton = ({ copyText, height, disabled=false, children }: CopyButtonPr
     });
   };
 
+  const buttonStyle = (() => {
+
+    // Default button style
+    let style = "bg-brandDark/10 text-center font-medium py-1 flex items-center justify-center gap-2 px-4 whitespace-nowrap rounded-lg";
+    let disabledStyle = disabled ? 'opacity-20 hover:opacity-20 cursor-not-allowed animate-pulse' : 'hover:opacity-80 cursor-pointer';
+    let copiedStyle = isCopied ? 'cursor-default bg-green-700/20 text-green-700' : 'text-brandDark dark:text-brandLight';
+
+    // Invisible button style
+    if (variant === "invisible") {
+      style = "rounded-lg";
+      copiedStyle = isCopied ? 'cursor-default bg-green-700/20 font-medium text-green-700 px-4' : '';
+    }
+
+    return `${disabledStyle} ${copiedStyle} ${style}`
+  })()
+
   return (
-    <button disabled={disabled} style={{ height: height }} onClick={handleCopy} ref={buttonRef} className={`${disabled ? 'opacity-20 hover:opacity-20 cursor-not-allowed animate-pulse' : 'hover:opacity-80 cursor-pointer'} ${isCopied ? 'cursor-default bg-green-700/20 text-green-700' : 'text-brandDark dark:text-brandLight'} bg-brandDark/10 text-center font-medium py-1 flex items-center justify-center gap-2 px-4 whitespace-nowrap rounded-lg`}>
-      {!isCopied && <svg className="w-3.5 stroke-[54px] fill-brandDark aspect-square" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><rect x="128" y="128" width="336" height="336" rx="57" ry="57" fill="none" stroke="currentColor" strokeLinejoin="round" /><path d="M383.5 128l.5-24a56.16 56.16 0 00-56-56H112a64.19 64.19 0 00-64 64v216a56.16 56.16 0 0056 56h24" fill="none" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" /></svg>}
+    <button disabled={disabled} style={{ height: height }} onClick={handleCopy} ref={buttonRef} className={buttonStyle}>
+      {!isCopied && variant !== "invisible" && <svg className="w-3.5 stroke-[54px] fill-brandDark aspect-square" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><rect x="128" y="128" width="336" height="336" rx="57" ry="57" fill="none" stroke="currentColor" strokeLinejoin="round" /><path d="M383.5 128l.5-24a56.16 56.16 0 00-56-56H112a64.19 64.19 0 00-64 64v216a56.16 56.16 0 0056 56h24" fill="none" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" /></svg>}
       {isCopied ? 'Copied' : children}
     </button>
   );

--- a/src/components/trade_components/GenerateOffer.tsx
+++ b/src/components/trade_components/GenerateOffer.tsx
@@ -284,8 +284,8 @@ const GenerateOffer: React.FC<GenerateOfferProps> = ({ data, devFee, setGenerate
                         {/* If swap, add dev fee on top of quote */}
                         <div className="flex gap-2 items-center">
                             <Image src={e[0].image_url} width={30} height={30} alt="Token logo" className="rounded-full outline-brandDark/20 p-0.5" />
-                            <p>{amountWithFee(e)}</p>
-                            <p>{process.env.NEXT_PUBLIC_XCH === "TXCH" && e[0].name === "Chia" ? "Testnet Chia" : e[0].name === "Pair Liquidity Token" ? e[0].short_name : e[0].name}</p>
+                            <CopyButton copyText={amountWithFee(e)}>{amountWithFee(e)} {process.env.NEXT_PUBLIC_XCH === "TXCH" && e[0].name === "Chia" ? "Testnet Chia" : e[0].name === "Pair Liquidity Token" ? e[0].short_name : e[0].name}</CopyButton>
+                            <p></p>
                         </div>
                         
                         {e[1] ? null :
@@ -446,7 +446,7 @@ const GenerateOffer: React.FC<GenerateOfferProps> = ({ data, devFee, setGenerate
                     
                     <p className="py-4 px-4 font-medium mb-12 bg-brandDark/10 rounded-xl">
                         <span>Suggested fee</span>
-                        <span className="font-normal pl-2 animate-fadeIn">{fee} {process.env.NEXT_PUBLIC_XCH}</span>
+                        <span><CopyButton copyText={fee}>{fee} {process.env.NEXT_PUBLIC_XCH}</CopyButton></span>
                     </p>
 
                     {/* High fee warning banner */}

--- a/src/components/trade_components/GenerateOffer.tsx
+++ b/src/components/trade_components/GenerateOffer.tsx
@@ -284,8 +284,8 @@ const GenerateOffer: React.FC<GenerateOfferProps> = ({ data, devFee, setGenerate
                         {/* If swap, add dev fee on top of quote */}
                         <div className="flex gap-2 items-center">
                             <Image src={e[0].image_url} width={30} height={30} alt="Token logo" className="rounded-full outline-brandDark/20 p-0.5" />
-                            <CopyButton copyText={amountWithFee(e)}>{amountWithFee(e)} {process.env.NEXT_PUBLIC_XCH === "TXCH" && e[0].name === "Chia" ? "Testnet Chia" : e[0].name === "Pair Liquidity Token" ? e[0].short_name : e[0].name}</CopyButton>
-                            <p></p>
+                            <CopyButton variant="invisible" copyText={amountWithFee(e).toString()}>{amountWithFee(e).toString()}</CopyButton>
+                            <p>{process.env.NEXT_PUBLIC_XCH === "TXCH" && e[0].name === "Chia" ? "Testnet Chia" : e[0].name === "Pair Liquidity Token" ? e[0].short_name : e[0].name}</p>
                         </div>
                         
                         {e[1] ? null :
@@ -446,7 +446,9 @@ const GenerateOffer: React.FC<GenerateOfferProps> = ({ data, devFee, setGenerate
                     
                     <p className="py-4 px-4 font-medium mb-12 bg-brandDark/10 rounded-xl">
                         <span>Suggested fee</span>
-                        <span><CopyButton copyText={fee}>{fee} {process.env.NEXT_PUBLIC_XCH}</CopyButton></span>
+                        <span className="animate-fadeIn font-normal pl-2">
+                            <CopyButton copyText={fee.toString()} variant="invisible" >{fee.toString()} {process.env.NEXT_PUBLIC_XCH || ""}</CopyButton>
+                        </span>
                     </p>
 
                     {/* High fee warning banner */}

--- a/src/components/trade_components/GenerateOffer.tsx
+++ b/src/components/trade_components/GenerateOffer.tsx
@@ -284,8 +284,10 @@ const GenerateOffer: React.FC<GenerateOfferProps> = ({ data, devFee, setGenerate
                         {/* If swap, add dev fee on top of quote */}
                         <div className="flex gap-2 items-center">
                             <Image src={e[0].image_url} width={30} height={30} alt="Token logo" className="rounded-full outline-brandDark/20 p-0.5" />
-                            <CopyButton variant="invisible" copyText={amountWithFee(e).toString()}>{amountWithFee(e).toString()}</CopyButton>
-                            <p>{process.env.NEXT_PUBLIC_XCH === "TXCH" && e[0].name === "Chia" ? "Testnet Chia" : e[0].name === "Pair Liquidity Token" ? e[0].short_name : e[0].name}</p>
+                            <CopyButton variant="invisible" copyText={amountWithFee(e).toString()}>
+                                {amountWithFee(e).toString()}
+                                <span className='pl-1.5'>{process.env.NEXT_PUBLIC_XCH === "TXCH" && e[0].name === "Chia" ? "Testnet Chia" : e[0].name === "Pair Liquidity Token" ? e[0].short_name : e[0].name}</span>
+                            </CopyButton>
                         </div>
                         
                         {e[1] ? null :


### PR DESCRIPTION
**User Story:**
As a user creating manual offer files, I want the ability to quickly and easily copy token and XCH values, so that I can streamline the process of generating offers and reduce the risk of errors.

**Description:**
In the current process of creating manual offer files, users have to manually select and copy the token, XCH and fee values, which can be time-consuming and prone to errors. To enhance the user experience and increase efficiency, we will utilize 'CopyButton' within the UI for token, XCH and fee values in the generate offers component.