### PR TITLE
Pass fee in mojos

### DIFF
--- a/src/components/trade_components/GenerateOffer.tsx
+++ b/src/components/trade_components/GenerateOffer.tsx
@@ -331,7 +331,7 @@ const GenerateOffer: React.FC<GenerateOfferProps> = ({ data, devFee, setGenerate
                 }
             ))
 
-        const fee = Number((pairAndQuote![1].fee / Math.pow(10, 12)).toFixed(12))
+        const fee = pairAndQuote![1].fee // Fee in mojos
 
         try {
             const offer = await walletManager.generateOffer(requestAssets, offerAssets, fee)

--- a/src/utils/walletIntegration/wallets/hoogiiWallet.tsx
+++ b/src/utils/walletIntegration/wallets/hoogiiWallet.tsx
@@ -90,7 +90,6 @@ class hoogiiWallet implements WalletIntegrationInterface {
 
   async generateOffer(requestAssets: generateOffer["requestAssets"], offerAssets: generateOffer["offerAssets"], fee: number | undefined): Promise<string | void> {
     // Hoogii wallet transaction signing logic
-    fee = Math.floor((fee ?? 0) * 10 ** 12)
     try {
       const params = {
         requestAssets: requestAssets.map(asset => ({


### PR DESCRIPTION
WalletConnect, Goby, Hoogii expect fee in mojos, rather than a decimal XCH value. This PR means TibetSwap suggested fee should now work correctly with integrated wallets :)